### PR TITLE
Implemented nice way to define a plugin

### DIFF
--- a/lib/plugins/base.js
+++ b/lib/plugins/base.js
@@ -14,7 +14,6 @@ var Store       = require('.')
 module.exports = class BasePlugin {
     constructor(name, requiredFunctions, dependants) {
         dependants = dependants || [];
-        functions = functions || {};
 
         this.methodMissing = null;
         var basePluginClass = this;
@@ -46,7 +45,7 @@ module.exports = class BasePlugin {
     checkIntegrity(){
         if(this.methodMissing) throw new BoolError(
             0, "EINTEGRITYFAILED",
-            `Integrity check for plugin has failed, method ${this.missingMethod} is missing`
+            `Integrity check for plugin has failed, method ${this.methodMissing} is missing`
         );
     }
 };

--- a/lib/plugins/base.js
+++ b/lib/plugins/base.js
@@ -8,32 +8,32 @@ var Store       = require('.')
  * @class BasePlugin
  * @description Base for plugins
  * @param {String} name - Name of plugin
- * @param {Object} functions - Functions that compose the plugin
  * @param {String[]} requiredFunctions - Required properties in plugin
  * @param {String[]} [dependants] - Dependencies for plugin
  */
 module.exports = class BasePlugin {
-    constructor(name, fields, requiredFields, dependants) {
+    constructor(name, requiredFunctions, dependants) {
         dependants = dependants || [];
-        fields = fields || {};
+        functions = functions || {};
+
+        this.methodMissing = null;
+        var basePluginClass = this;
 
         this.name = name;
         for(var dependant in dependants){
             try{
-                var Dependant = require(dependants[dependant]);
+                require(dependants[dependant]);
             } catch (err) {
                 throw err;
             }
         }
 
-        this.priority = fields.priority || 0;
-        for(var key of requiredFields){
-            if(fields[key]) {
-                this[key] = fields[key];
-            } else {
-                this[key] = undefined;
+        requiredFields.forEach(function (field) {
+            if ( !basePluginClass[field] && 
+                 typeof basePluginClass[field] !== 'function' ) {
+                basePluginClass.methodMissing = field;
             }
-        }
+        })
 
         store.register(this);
     }
@@ -44,11 +44,9 @@ module.exports = class BasePlugin {
      * @throws {BoolError} In case a field is not implemented
      */
     checkIntegrity(){
-        for(var key in this){
-            if(this[key] === undefined) throw new BoolError(
-                0, "EINTEGRITYFAILED",
-                "Integrity check for plugin has failed"
-            );
-        }
+        if(this.methodMissing) throw new BoolError(
+            0, "EINTEGRITYFAILED",
+            `Integrity check for plugin has failed, method ${this.missingMethod} is missing`
+        );
     }
 };

--- a/lib/plugins/classes/database_loader.js
+++ b/lib/plugins/classes/database_loader.js
@@ -10,7 +10,7 @@ var BasePlugin = require('../base');
  */
 module.exports = class DatabaseLoader extends BasePlugin {
     constructor(name, functions, dependants) {
-        super(name, functions, [
+        super(name, [
             /**
              * @function API.DatabaseLoader#openDatabase
              * @description Takes connection parameters to open a database

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 let instance = null;
-var BoolError = require('../error');
 
 /**
 * @class PluginStore


### PR DESCRIPTION
Hola Pablo,

Estaba viendo la manera de definir bien **bool** un plugin serìa màs ordenado, menos tedioso y màs pro. Asì mismo aplica para los demas plugins ubicados en "classes". Con el cambio se lograria esto: 

``` JS
class DatabaseLoader extends BasePlugin {

    constructor(name, dependants) {
        super(name, ['open', 'close'], dependants)
    }
}

/**
 * Nice Plugin declaration
 */
class BoolJSMysql extends DatabaseLoader 
{
    constructor(name) {
        super(name)
    }

    /**
     * Override
     */
    open() {
        console.log('Open db connection')
    }

    /**
     * Override
     */
    close() {
        console.log('Close db connection')
    }
}

var plugin = new BoolJSMysql('booljs-mysql')
plugin.open()
plugin.close()
```

> **Antigua forma**: La responsabilidad queda encerrada dentro del wrap ejemplo para tipo base de datos "DatabaseLoader" y no dentro del plugin concreto.

Me parece que queda bien chulo asì :100: revisalo y me cuentas. 
- [x] Adjust base class
- [x] Implement in child classes
- [x] Pass tests
