### PR TITLE
Finally fixed middleware sort issue

### DIFF
--- a/lib/plugins/base.js
+++ b/lib/plugins/base.js
@@ -16,6 +16,9 @@ module.exports = class BasePlugin {
     constructor (name, classInterface = [], dependants = []) {
         let missingMethods = [];
 
+        /** @member {Object} name */
+        this.name = name;
+
         for (let route of dependants) {
             try {
                 const Dependant = require(route);

--- a/lib/plugins/classes/route_middleware.js
+++ b/lib/plugins/classes/route_middleware.js
@@ -30,6 +30,8 @@ module.exports = class RouteMiddleware extends Middleware {
         this.type = type;
         /** @member {Object} policies */
         this.policies = policies;
+        /** @member {Object} priority */
+        this.priority = this.priority || 0;
     }
 
     checkParameters (type, policies) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "booljs.api",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Bool.js - API Core",
   "main": "lib/index.js",
   "license": "GPL-3.0",


### PR DESCRIPTION
- Declared `name` property to `BasePlugin`, property that was missing and was part of the sorting.
- Set default value for `priority` to 0. The default number was `undefined`, thus making a comparison impossible due to the `NaN` response to the comparison between a number and `undefined`.